### PR TITLE
Improve dashboard appearance and email flow

### DIFF
--- a/dashboard/scheduler.py
+++ b/dashboard/scheduler.py
@@ -4,6 +4,7 @@ import importlib
 import os
 import traceback
 from datetime import datetime
+from pytz import timezone
 from apscheduler.schedulers.background import BackgroundScheduler
 from apscheduler.triggers.cron import CronTrigger
 from pywintypes import com_error
@@ -28,7 +29,7 @@ def run_task_by_id(task_id: int, offset: int = 1):
     if not task or not task.enabled:
         return None, "Task is disabled or does not exist."
 
-    start = datetime.utcnow()
+    start = datetime.now(timezone(SCHEDULER_TIMEZONE)).replace(tzinfo=None)
     try:
         module = importlib.import_module(task.module_path)
         fn     = getattr(module, task.function_name)

--- a/dashboard/static/css/custom.css
+++ b/dashboard/static/css/custom.css
@@ -1,8 +1,9 @@
 /* custom.css */
 
-/* Make the page background a light gray */
+/* Dark theme background */
 body {
-  background-color: #f7f7f7;
+  background-color: #212529;
+  color: #f8f9fa;
 }
 
 /* Start each card invisible and shifted down,
@@ -11,9 +12,9 @@ body {
   opacity: 0;
   transform: translateY(20px);
   transition: opacity 0.5s ease, transform 0.5s ease;
-  border-radius: 0.5rem;       /* slightly rounded corners */
-  box-shadow: 0 1px 3px rgba(0,0,0,0.1); /* subtle shadow */
-  background-color: #ffffff;   /* ensure cards stay white on gray bg */
+  border-radius: 0.5rem;
+  box-shadow: 0 1px 3px rgba(0,0,0,0.6);
+  background-color: #343a40;
 }
 .task-card.visible {
   opacity: 1;
@@ -53,7 +54,7 @@ body {
 
 /* Table row hover */
 .table-hover tbody tr:hover {
-  background-color: #f1f1f1;
+  background-color: rgba(255,255,255,0.05);
 }
 
 /* Remove default focus outline on buttons */
@@ -76,4 +77,9 @@ body {
 /* “Run All” button in navbar (slightly thicker font) */
 .navbar .btn-danger {
   font-weight: 600;
+}
+
+#loadingOverlay p {
+  color: #fff;
+  font-size: 1.2rem;
 }

--- a/dashboard/static/js/custom.js
+++ b/dashboard/static/js/custom.js
@@ -7,4 +7,14 @@ document.addEventListener("DOMContentLoaded", () => {
       card.classList.add("visible");
     }, idx * 100); // 100ms stagger between cards
   });
+
+  // Show overlay while waiting for long-running tasks
+  const overlay = document.getElementById("loadingOverlay");
+  document.querySelectorAll("form.needs-wait").forEach(f => {
+    f.addEventListener("submit", () => {
+      if (overlay) {
+        overlay.classList.remove("d-none");
+      }
+    });
+  });
 });

--- a/dashboard/templates/base.html
+++ b/dashboard/templates/base.html
@@ -5,10 +5,10 @@
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>{% block title %}Dashboard{% endblock %}</title>
 
-  <!-- Bootstrap 4 (Dark Navbar + Cards) -->
+  <!-- Bootswatch Darkly theme for a modern dark appearance -->
   <link
     rel="stylesheet"
-    href="https://stackpath.bootstrapcdn.com/bootstrap/4.5.2/css/bootstrap.min.css"
+    href="https://cdn.jsdelivr.net/npm/bootswatch@4.5.2/dist/darkly/bootstrap.min.css"
     crossorigin="anonymous"
   />
 
@@ -30,7 +30,7 @@
   <!-- Your custom overrides -->
   <link rel="stylesheet" href="{{ url_for('static', filename='css/custom.css') }}" />
 </head>
-<body class="bg-light">
+<body class="bg-dark text-light">
 
   <!-- Dark Navbar -->
   <nav class="navbar navbar-expand-lg navbar-dark bg-dark">
@@ -57,7 +57,7 @@
             <form
               method="post"
               action="{{ url_for('main.run_all_tasks') }}"
-              class="form-inline mr-2"
+              class="form-inline mr-2 needs-wait"
             >
               <label for="runAllOffset" class="text-light mb-0 mr-2">Offset:</label>
               <input
@@ -76,7 +76,7 @@
             <form
               method="post"
               action="{{ url_for('main.run_all_tasks') }}"
-              class="form-inline"
+              class="form-inline needs-wait"
             >
               <input
                 type="hidden"
@@ -93,6 +93,14 @@
       </div>
     </div>
   </nav>
+
+  <!-- Processing overlay -->
+  <div id="loadingOverlay" class="d-none position-fixed w-100 h-100" style="top:0;left:0;background:rgba(0,0,0,0.6);z-index:1050;">
+    <div class="d-flex flex-column justify-content-center align-items-center h-100">
+      <div class="spinner-border text-light" role="status" style="width:3rem;height:3rem;"></div>
+      <p class="mt-3">Processing…</p>
+    </div>
+  </div>
 
   <div class="container my-4">
     {% with messages = get_flashed_messages(with_categories=true) %}

--- a/dashboard/templates/task_detail.html
+++ b/dashboard/templates/task_detail.html
@@ -60,7 +60,7 @@
   <div class="card mb-4">
     <div class="card-body">
       <h5 class="card-title">Run This Task Manually</h5>
-      <form method="post" action="{{ url_for('main.task_run_now', task_id=task.id) }}" class="form-inline">
+      <form method="post" action="{{ url_for('main.task_run_now', task_id=task.id) }}" class="form-inline needs-wait">
         <label for="offsetInput" class="mr-2">Offset (months back):</label>
         <input
           type="number"

--- a/dashboard/views.py
+++ b/dashboard/views.py
@@ -6,7 +6,8 @@ from flask import (
 )
 from dashboard.models import db, Task, TaskLog
 from dashboard.scheduler import run_task_by_id, schedule_all_tasks
-from nea_reports import run_all, send_email
+from nea_reports import run_all, send_email, send_simple, wait_reply
+import os
 
 main_bp = Blueprint("main", __name__)
 
@@ -105,6 +106,17 @@ def run_all_tasks():
                 f"Run All complete—email sent with {len(all_generated_files)} attachments.",
                 "success"
             )
+            if os.environ.get("POLL_FOR_REPLY", "True").lower() in ("1","true","yes"):
+                reply = wait_reply(["yes", "no"])
+                if reply:
+                    if "yes" in reply:
+                        send_simple("Submission Approved", "Proceeding with submission.")
+                        flash("Approval received via email.", "info")
+                    elif "no" in reply:
+                        send_simple("Submission Aborted", "Submission aborted per reply.")
+                        flash("Submission aborted per email reply.", "warning")
+                else:
+                    flash("No approval reply received within timeout.", "secondary")
         except Exception as e:
             flash(f"Email sending failed: {e}", "danger")
     else:

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,4 @@ Pillow
 pytesseract
 python-dotenv
 pywin32; sys_platform == 'win32'
+pytz


### PR DESCRIPTION
## Summary
- update UI with a dark theme and add a loading overlay
- show overlay when submitting forms
- support Asia/Manila timestamps
- poll for yes/no email replies after sending the consolidated email
- add `pytz` requirement

## Testing
- `python -m py_compile dashboard/*.py nea_reports.py tasks/*.py run.py config.py`

------
https://chatgpt.com/codex/tasks/task_e_6846a278a24c8333acf0c9368e5256f7