### PR TITLE
Add debug prints and infinite reply polling

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -22,7 +22,7 @@ JPG_DPI=600
 POLL_FOR_REPLY=True
 POLL_TIMEOUT_MIN=30
 
-POLL_INTERVAL_SEC=10
+POLL_INTERVAL_SEC=5
 
 # Local timezone used for timestamps
 APP_TIMEZONE=Asia/Manila

--- a/dashboard/views.py
+++ b/dashboard/views.py
@@ -106,12 +106,23 @@ def run_all_tasks():
                 f"Run All complete—email sent with {len(all_generated_files)} attachments.",
                 "success"
             )
-            if POLL_FOR_REPLY and wait_reply(["yes", "approved", "proceed"]):
-                send_simple(
-                    f"Re: {subject}",
-                    "Approval received. Proceeding with submission of the files.",
-                    reply_to_msgid=msgid,
+            if POLL_FOR_REPLY:
+                result = wait_reply(
+                    ["yes", "approved", "proceed", "go", "go ahead"],
+                    ["no", "abort", "cancel", "stop"],
                 )
+                if result == "yes":
+                    send_simple(
+                        f"Re: {subject}",
+                        "Approval received. Proceeding with submission of the files.",
+                        reply_to_msgid=msgid,
+                    )
+                elif result == "no":
+                    send_simple(
+                        f"Re: {subject}",
+                        "Process aborted per reply.",
+                        reply_to_msgid=msgid,
+                    )
         except Exception as e:
             flash(f"Email sending failed: {e}", "danger")
     else:


### PR DESCRIPTION
## Summary
- debug prints when sending email or waiting for replies
- poll for email replies every 5s with no timeout
- handle approval and abort replies
- lower polling interval in `.env.example`

## Testing
- `python -m py_compile nea_reports.py dashboard/views.py dashboard/app.py dashboard/models.py dashboard/scheduler.py run.py`
- `python -m py_compile tasks/*.py`

------
https://chatgpt.com/codex/tasks/task_e_6848db6c3ae08333992e25edf1ed2cfa