### PR TITLE
Fix reply polling logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ This project provides a web based dashboard for orchestrating monthly National E
 * Background scheduling via APScheduler
 * Manual or scheduled execution of five reporting steps
 * Email notifications with optional reply polling
+  that filters out old or unrelated emails
 * Configurable timezone for scheduler and database timestamps
 * Minimal Bootstrap 4 based UI
 

--- a/dashboard/views.py
+++ b/dashboard/views.py
@@ -101,6 +101,7 @@ def run_all_tasks():
         )
 
         try:
+            send_time = datetime.now(APP_TIMEZONE)
             msgid = send_email(subject, body, all_generated_files)
             flash(
                 f"Run All complete—email sent with {len(all_generated_files)} attachments.",
@@ -110,6 +111,8 @@ def run_all_tasks():
                 result = wait_reply(
                     ["yes", "approved", "proceed", "go", "go ahead"],
                     ["no", "abort", "cancel", "stop"],
+                    after=send_time,
+                    thread_msgid=msgid,
                 )
                 if result == "yes":
                     send_simple(


### PR DESCRIPTION
## Summary
- prevent wait_reply from accepting old or unrelated emails by checking
  message thread ID and timestamp
- pass the new parameters when polling in `run_all`
- document the new behaviour

## Testing
- `python -m py_compile nea_reports.py dashboard/views.py`
- `python populate_tasks.py` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_6848ded86f0c83339a725cd3ddf46994